### PR TITLE
fixed sourced vars

### DIFF
--- a/1_makeCA.sh
+++ b/1_makeCA.sh
@@ -1,4 +1,5 @@
 # /bin/bash
-source ./dirs.sh
+. ./dirs.sh
+
 openssl genrsa -out $cadir/rootCAKey.pem 2048
 openssl req -x509 -config ./openssl-CA.conf -new -nodes -key $cadir/rootCAKey.pem -days 3650 -out $cadir/rootCACert.pem

--- a/2_initial_provision.sh
+++ b/2_initial_provision.sh
@@ -1,5 +1,5 @@
 # /bin/bash
-source ./dirs.sh
+. ./dirs.sh
 set -e
 
 # This will make the EK persistent
@@ -23,5 +23,6 @@ tpm2_readpublic -c $cdir/ak.ctx -f pem -o $cdir/ak.pem
 echo -e "\nCreate an AK Certificate"
 #openssl req -key $cdir/ak.pem -new -out $cdir/ak.pem
 openssl req -new -noenc -config ./openssl-AK.conf -keyout $cdir/ak-fake.key -out $cdir/ak-fake.csr
+
 openssl x509 -req -CA $cadir/rootCACert.pem -CAkey $cadir/rootCAKey.pem -force_pubkey $cdir/ak.pem -in $cdir/ak-fake.csr -out $cdir/ak.cert
 rm $cdir/ak-fake.*

--- a/3_createkey.sh
+++ b/3_createkey.sh
@@ -1,5 +1,5 @@
 # /bin/bash
-source ./dirs.sh
+. ./dirs.sh
 set -e
 
 # General notes:

--- a/4_sendtoaca.sh
+++ b/4_sendtoaca.sh
@@ -1,3 +1,3 @@
 # /bin/bash
-source ./dirs.sh
+. ./dirs.sh
 cp $cdir/attestation_statement.tar $acadir

--- a/5_verifykey.sh
+++ b/5_verifykey.sh
@@ -1,5 +1,5 @@
 # /bin/bash
-source ./dirs.sh
+. ./dirs.sh
 set -e
 # Expanding attestation_statement
 echo -e "*** Expanding attestation_statement ***"

--- a/clean.sh
+++ b/clean.sh
@@ -1,5 +1,5 @@
 # /bin/bash
-source ./dirs.sh
+. ./dirs.sh
 
 # Clear TPM
 echo -e "Clearing TPM"

--- a/dirs.sh
+++ b/dirs.sh
@@ -1,4 +1,4 @@
 # /bin/bash
-cdir='./client'
-cadir='./ca'
-acadir='./aca'
+export cdir='./client'
+export cadir='./ca'
+export acadir='./aca'


### PR DESCRIPTION
It turns out that `source ./dirs.sh` doesn't work; this created all sorts of files in my filesystem root `/`.

It needs to be `. ./dirs.sh`.